### PR TITLE
Update to newer SVN rev and add lldb-gdbserver binary

### DIFF
--- a/lldb-svn/PKGBUILD
+++ b/lldb-svn/PKGBUILD
@@ -79,8 +79,9 @@ package() {
 
   cd "$srcdir/llvm/build"
 
-  # Install the lldb binary
+  # Install the lldb binaries
   install -Dm755 bin/lldb "$pkgdir/usr/bin/lldb"
+  install -Dm755 bin/lldb-gdbserver "$pkgdir/usr/bin/lldb-gdbserver"
 
   # Install the lldb library
   install -Dm755 lib/liblldb.so "$pkgdir/usr/lib/liblldb.so"


### PR DESCRIPTION
I originally updated the SVN rev to try to get lldb-mi working, but in its current state, it doesn't seem to respond to any GDB/MI commands (nor accept --interpreter=mi\* command line parameters).  I may still come back to try again with that, but getting a newer version of LLDB with the gdbserver support is also helpful :)
